### PR TITLE
Fix `insert` warnings

### DIFF
--- a/cloudmesh/mongo/CmDatabase.py
+++ b/cloudmesh/mongo/CmDatabase.py
@@ -207,7 +207,7 @@ class CmDatabase(object):
                 else:
                     entry['cm']['created'] = entry['cm']['modified'] = str(
                         datetime.utcnow())
-                    self.col.insert(entry)
+                    self.col.insert_one(entry)
             except Exception as e:
                 Console.error("uploading document {entry}".format(
                     entry=str(entry)))


### PR DESCRIPTION
The use of `collection.insert()` is deprecated. PyMongo recommends using `insert_one()` or `insert_many()`.  Update to use insert_one since it's a single document.

This fixes a warning in my PyTest:

```
tests/test_flowdb.py::Test_flowdb::test_start_flow
  /home/rob/github/cmv4/cloudmesh-cloud/cloudmesh/mongo/CmDatabase.py:210: DeprecationWarning: insert is deprecated. Use insert_one or insert_many instead.
    self.col.insert(entry)
```