### PR TITLE
Extend key command's generation and verification functionality

### DIFF
--- a/cloudmesh/config/command/config.py
+++ b/cloudmesh/config/command/config.py
@@ -32,6 +32,7 @@ class ConfigCommand(PluginCommand):
              config secinit
              config security add (--secret=REGEXP | --exception=REGEXP )
              config security rmv (--secret=REGEXP | --exception=REGEXP )
+             config security list
              config encrypt 
              config decrypt [--nopass]
              config edit [ATTRIBUTE]
@@ -88,8 +89,13 @@ class ConfigCommand(PluginCommand):
 
                 cms config encrypt 
                     Encrypts the config data at-rest. This means that the data
-                    is encrypted when not in use. This command checks two
-                    attributes within the cloudmesh config file
+                    is encrypted when not in use. This command is reliant upon
+                    the cloudmesh.security.secrets attribute and the
+                    cloudmesh.security.exceptions attribute within the
+                    cloudmesh.yaml file. Note, that the encrypted data is not 
+                    encrypted upon request/query to the attribute. This means 
+                    you must decrypt the config when needed in use and
+                    re-encrypt when not using the file, or delivering the file.
 
                         1. cloudmesh.security.secrets:
                             This attribute will hold a list of python regular
@@ -103,9 +109,22 @@ class ConfigCommand(PluginCommand):
                             expressions that detail which attributes will not
                             be encrypted by the command. 
                             ex) .*pubkey.*: ensures no pubkey path is encrypted 
+                    
+                security add --secret=REGEXP 
+                    Adds valid REGEXP to the cloudmesh.security.secrets section
 
-                    Currently the data will not be decrypted upon query. 
-                    This means that you should decrypt the data when needed.
+                security rmv --secret=REGEXP 
+                    Removes REGEXP from the cloudmesh.security.secrets section
+
+                security add --exception=REGEXP
+                    Adds valid REGEXP to cloudmesh.security.exceptions section
+
+                security rmv --exception=REGEXP
+                    Removes REGEXP from cloudmesh.security.exceptions section
+
+                security list
+                    Prints a list of all the attribute dot-paths that are 
+                    referenced by cms config encryption and decryption commands
 
                 cms config decrypt 
                     Decrypts the config data that was held in rest. This 
@@ -299,6 +318,12 @@ class ConfigCommand(PluginCommand):
             secpath = path_expand(config['cloudmesh.security.secpath'])
             if not os.path.isdir(secpath):
                 Shell.mkdir(secpath)  # Use Shell that makes all dirs as needed
+
+        elif arguments.security and arguments.list:
+            config = Config()
+            secrets = config.get_list_secrets()
+            for s in secrets:
+                Console.msg(s)
 
         elif arguments.security:
             # Get the regular expression from command line

--- a/cloudmesh/key/command/key.py
+++ b/cloudmesh/key/command/key.py
@@ -48,7 +48,7 @@ class KeyCommand(PluginCommand):
              key group delete [--group=GROUPNAMES] [NAMES] [--dryrun]
              key group list [--group=GROUPNAMES] [--output=OUTPUT]
              key group export --group=GROUNAMES --filename=FILENAME
-             key gen (ssh | pem) [--filename=FILENAME] [--nopass] [--set_path]
+             key gen (ssh | pem) [--filename=FILENAME] [--nopass] [--set_path] [--force]
              key verify (ssh | pem) [--filename=FILENAME] [--pub]
 
            Arguments:
@@ -206,6 +206,7 @@ class KeyCommand(PluginCommand):
                        'dir',
                        'dryrun',
                        'filename',
+                       'force',
                        'name',
                        'nopass',
                        'output',
@@ -402,6 +403,7 @@ class KeyCommand(PluginCommand):
         elif arguments.gen:
             """
             key gen (ssh | pem) [--filename=FILENAME] [--nopass] [--set_path]
+                    [--force]
             Generate an RSA key pair with pem or ssh encoding for the public
             key. The private key is always encoded as a PEM file.
             """
@@ -436,7 +438,7 @@ class KeyCommand(PluginCommand):
                 uk_path = rk_path + ".pub"
 
             # Set the path if requested
-            if arguments.set_path and arguments.filename:
+            if arguments.set_path:
                 config['cloudmesh.security.privatekey'] = rk_path
                 config['cloudmesh.security.publickey'] = uk_path
                 config.save()
@@ -452,7 +454,7 @@ class KeyCommand(PluginCommand):
             # Serialize and write the private key to the path
             sr = kh.serialize_key(key = r, key_type = "PRIV", encoding = "PEM",
                                   format = "PKCS8", ask_pass = ap)
-            kh.write_key(key = sr, path = rk_path)
+            kh.write_key(key = sr, path = rk_path, force=arguments.force)
 
             # Determine the public key format and encoding
             enc = None
@@ -467,7 +469,7 @@ class KeyCommand(PluginCommand):
             # Serialize and write the public key to the path
             su = kh.serialize_key(key = u, key_type = "PUB", encoding = enc,
                                   format = forma, ask_pass = False)
-            kh.write_key(key = su, path = uk_path)
+            kh.write_key(key = su, path = uk_path, force=arguments.force)
 
             Console.ok("Success")
 

--- a/cloudmesh/key/command/key.py
+++ b/cloudmesh/key/command/key.py
@@ -437,6 +437,19 @@ class KeyCommand(PluginCommand):
                 rk_path = path_expand("~/.ssh/id_rsa")
                 uk_path = rk_path + ".pub"
 
+            # Check if the file exist, if so confirm overwrite
+            def check_exists(path):
+                if os.path.exists(path):
+                    Console.info(f"{path} already exists")
+                    ovwr_r = yn_choice(message=f"overwrite {path}?", default="N")
+                    if not ovwr_r:
+                        Console.info(f"Not overwriting {path}. Quitting")
+                        sys.exit()
+
+            if not arguments.force:
+                check_exists(rk_path)
+                check_exists(uk_path)
+
             # Set the path if requested
             if arguments.set_path:
                 config['cloudmesh.security.privatekey'] = rk_path
@@ -454,7 +467,9 @@ class KeyCommand(PluginCommand):
             # Serialize and write the private key to the path
             sr = kh.serialize_key(key = r, key_type = "PRIV", encoding = "PEM",
                                   format = "PKCS8", ask_pass = ap)
-            kh.write_key(key = sr, path = rk_path, force=arguments.force)
+
+            # Force write the key (since we check file existence above)
+            kh.write_key(key = sr, path = rk_path, force = True)
 
             # Determine the public key format and encoding
             enc = None
@@ -469,7 +484,9 @@ class KeyCommand(PluginCommand):
             # Serialize and write the public key to the path
             su = kh.serialize_key(key = u, key_type = "PUB", encoding = enc,
                                   format = forma, ask_pass = False)
-            kh.write_key(key = su, path = uk_path, force=arguments.force)
+
+            # Force write the key (since we check file existence above)
+            kh.write_key(key = su, path = uk_path, force = True)
 
             Console.ok("Success")
 

--- a/cloudmesh/key/command/key.py
+++ b/cloudmesh/key/command/key.py
@@ -77,9 +77,26 @@ class KeyCommand(PluginCommand):
                file. One such value is cloudmesh.profile.user
 
                Manages public keys is an essential component of accessing
-               virtual machine sin the cloud. There are a number of sources
-               where you can find public keys. This includes teh ~/.ssh
-               directory and for example github.
+               virtual machines in the cloud. There are a number of sources
+               where you can find public keys. This includes the ~/.ssh
+               directory and for example github. If do not already have a
+               public-private key pairs they can be generated using cloudmesh
+
+               key gen ssh 
+                   This will create the public-private keypair of ~/.ssh/id_rsa
+                   and ~/.ssh/id_rsa.pub in OpenSSH format
+
+               key gen pem 
+                   This will create the public-private keypair of ~/.ssh/id_rsa
+                   and ~/.ssh/id_rsa.pub in PEM format
+
+               key gen (ssh | pem) --filename=~/.cloudmesh/foobar
+                   This will generate the public-private key pair of 
+                   ~/.cloudmesh/foobar and ~/.cloudmesh/foobar.pub
+
+               key gen (ssh | pem) --filename=~/.cloudmesh/foobar --set_path
+                   This will generate the keys as stated above, but it will
+                   also set cloudmesh to use these keys for encryption.
 
                Keys will be uploaded into cloudmesh database with the add
                command under the given NAME. If the name is not specified the name
@@ -415,8 +432,8 @@ class KeyCommand(PluginCommand):
                     rk_path = fp
                     uk_path = rk_path + ".pub"
             else:
-                rk_path = path_expand(config['cloudmesh.security.privatekey'])
-                uk_path = path_expand(config['cloudmesh.security.publickey'])
+                rk_path = path_expand("~/.ssh/id_rsa")
+                uk_path = rk_path + ".pub"
 
             # Set the path if requested
             if arguments.set_path and arguments.filename:
@@ -466,10 +483,11 @@ class KeyCommand(PluginCommand):
             fp = None
             if arguments.filename is None:
                 config = Config()
+                kp = path_expand("~/.ssh/id_rsa")
                 if arguments.pub:
-                    fp = config['cloudmesh.profile.publickey']
+                    fp = kp + ".pub"
                 else:
-                    fp = config['cloudmesh.security.privatekey']
+                    fp = kp
             else:
                 fp = arguments.filename
 


### PR DESCRIPTION
Extend the `cms key` command to 
1) Use ~/.ssh/id_rsa or ~/.ssh/id_rsa.pub for all defaults
2) Add checks for existing files before key creation (and password query)
3) Add --force argument for key generation that automatically overwrites files
4) Add functionality to reformat a keys encoding, format, and/or password
5) Extend verification command to check for passwords

This [cms config PR](https://github.com/cloudmesh/cloudmesh-configuration/pull/12) will need to be integrated first, since this PR is reliant upon the introduced (--force) argument and the new function (reformat_key)